### PR TITLE
Handling multiple outputs from dotnet pack

### DIFF
--- a/pre_commit/languages/dotnet.py
+++ b/pre_commit/languages/dotnet.py
@@ -59,22 +59,19 @@ def install_environment(
 
         # Determine tool from the packaged file <tool_name>.<version>.nupkg
         build_outputs = os.listdir(os.path.join(prefix.prefix_dir, build_dir))
-        if len(build_outputs) != 1:
-            raise NotImplementedError(
-                f"Can't handle multiple build outputs. Got {build_outputs}",
-            )
-        tool_name = build_outputs[0].split('.')[0]
+        for output in build_outputs:
+            tool_name = output.split('.')[0]
 
-        # Install to bin dir
-        helpers.run_setup_cmd(
-            prefix,
-            (
-                'dotnet', 'tool', 'install',
-                '--tool-path', os.path.join(envdir, BIN_DIR),
-                '--add-source', build_dir,
-                tool_name,
-            ),
-        )
+            # Install to bin dir
+            helpers.run_setup_cmd(
+                prefix,
+                (
+                    'dotnet', 'tool', 'install',
+                    '--tool-path', os.path.join(envdir, BIN_DIR),
+                    '--add-source', build_dir,
+                    tool_name,
+                ),
+            )
 
         # Clean the git dir, ignoring the environment dir
         clean_cmd = ('git', 'clean', '-ffxd', '-e', f'{ENVIRONMENT_DIR}-*')

--- a/testing/resources/dotnet_hooks_combo_repo/.pre-commit-hooks.yaml
+++ b/testing/resources/dotnet_hooks_combo_repo/.pre-commit-hooks.yaml
@@ -1,0 +1,12 @@
+-   id: dotnet-example-hook
+    name: Test Project 1
+    description: Test Project 1
+    entry: proj1
+    language: dotnet
+    stages: [commit]
+-   id: proj2
+    name: Test Project 2
+    description: Test Project 2
+    entry: proj2
+    language: dotnet
+    stages: [commit]    

--- a/testing/resources/dotnet_hooks_combo_repo/dotnet_hooks_combo_repo.sln
+++ b/testing/resources/dotnet_hooks_combo_repo/dotnet_hooks_combo_repo.sln
@@ -1,0 +1,28 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30114.105
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "proj1", "proj1\proj1.csproj", "{38A939C3-DEA4-47D7-9B75-0418C4249662}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "proj2", "proj2\proj2.csproj", "{4C9916CB-165C-4EF5-8A57-4CB6794C1EBF}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{38A939C3-DEA4-47D7-9B75-0418C4249662}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{38A939C3-DEA4-47D7-9B75-0418C4249662}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{38A939C3-DEA4-47D7-9B75-0418C4249662}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{38A939C3-DEA4-47D7-9B75-0418C4249662}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4C9916CB-165C-4EF5-8A57-4CB6794C1EBF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C9916CB-165C-4EF5-8A57-4CB6794C1EBF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4C9916CB-165C-4EF5-8A57-4CB6794C1EBF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4C9916CB-165C-4EF5-8A57-4CB6794C1EBF}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/testing/resources/dotnet_hooks_combo_repo/proj1/Program.cs
+++ b/testing/resources/dotnet_hooks_combo_repo/proj1/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace proj1
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.Write("Hello from dotnet!\n");
+        }
+    }
+}

--- a/testing/resources/dotnet_hooks_combo_repo/proj1/proj1.csproj
+++ b/testing/resources/dotnet_hooks_combo_repo/proj1/proj1.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>proj1</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>    
+  </PropertyGroup>
+
+</Project>

--- a/testing/resources/dotnet_hooks_combo_repo/proj2/Program.cs
+++ b/testing/resources/dotnet_hooks_combo_repo/proj2/Program.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace proj2
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/testing/resources/dotnet_hooks_combo_repo/proj2/proj2.csproj
+++ b/testing/resources/dotnet_hooks_combo_repo/proj2/proj2.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>proj2</ToolCommandName>
+    <PackageOutputPath>./nupkg</PackageOutputPath>    
+  </PropertyGroup>
+
+</Project>

--- a/tests/repository_test.py
+++ b/tests/repository_test.py
@@ -1042,6 +1042,7 @@ def test_local_perl_additional_dependencies(store):
     (
         'dotnet_hooks_csproj_repo',
         'dotnet_hooks_sln_repo',
+        'dotnet_hooks_combo_repo'
     ),
 )
 def test_dotnet_hook(tempdir_factory, store, repo):


### PR DESCRIPTION
This will enable handling of multiple outputs from a `dotnet pack` command, meaning that a single repo can contain several projects.